### PR TITLE
[Issue #39] Ensure interim videos are generated with right format.

### DIFF
--- a/ly2video.py
+++ b/ly2video.py
@@ -1494,6 +1494,7 @@ def getOutputFile(options):
 def callFfmpeg(ffmpeg, options, wavPath, outputFile):
     fps = str(options.fps)
     framePath = tmpPath('notes', 'frame%d.png')
+    fileExtension = os.path.splitext(outputFile)[1][1:].strip()
 
     if not options.titleAtStart:
         cmd = [
@@ -1510,7 +1511,7 @@ def callFfmpeg(ffmpeg, options, wavPath, outputFile):
         # generate silent title video
         silentAudio    = generateSilence(options.titleDuration)
         titleFramePath = tmpPath('title', 'frame%d.png')
-        titlePath      = tmpPath('title.mpg')
+        titlePath      = tmpPath(''.join(['title.', fileExtension]))
         cmd = [
             ffmpeg,
             "-f", "image2",
@@ -1524,7 +1525,7 @@ def callFfmpeg(ffmpeg, options, wavPath, outputFile):
         safeRun(cmd, exitcode=14)
 
         # generate video with notes
-        notesPath = tmpPath("notes.mpg")
+        notesPath = tmpPath(''.join(['notes.', fileExtension]))
         cmd = [
             ffmpeg,
             "-f", "image2",
@@ -1538,7 +1539,7 @@ def callFfmpeg(ffmpeg, options, wavPath, outputFile):
         safeRun(cmd, exitcode=15)
 
         # join the files
-        joinedPath = tmpPath('joined.mpg')
+        joinedPath = tmpPath(''.join(['joined.', fileExtension]))
         if sys.platform.startswith("linux"):
             safeRun("cat '%s' '%s' > %s" % (titlePath, notesPath, joinedPath), shell=True)
         elif sys.platform.startswith("win"):


### PR DESCRIPTION
This tweak should ensure that interim videos created in order to have a title page are created using the same format as the output video.  It has been tested using avconv 0.8.5 but needs to be tested also with FFmpeg.

Cautionary note: when I try and create a video with title page, the notes aren't included in the final video.  I'm not sure if this is a fault of my patch, of avconv, or of ly2video.
