### PR TITLE
workaround for LilyPond issue 2569

### DIFF
--- a/ly2video.py
+++ b/ly2video.py
@@ -212,6 +212,13 @@ def getLeftmostGrobsByMoment(output, dpi, leftPaperMarginPx):
     corresponds to the left-most grob at that moment.
     """
 
+    i = output.find("*** Warning")
+    while i > 0 and len(output) > 200:
+        debug("Invalid LilyPond output detected: " + output[i-20:i+190])
+        output = output[0:i-1] + output[i+154:]
+        progress("Removed incorrect LilyPond message (Issue 2569) at position {}, length is now {}".format(i, len(output)))
+        i = output.find("*** Warning")
+
     lines = output.split('\n')
 
     leftmostGrobs = { }


### PR DESCRIPTION
This is a workaround for LilyPond issue 2569 ( https://code.google.com/p/lilypond/issues/detail?id=2569 ) which causes on MacOSX an incorrect message in output that blocks the execution of ly2video

This is my very first usage of ly2video... maybe a better workaround can be written; this is a sample of the incorrect output message:

ly2video: (    33.4460741473566000,     34.7622521473566000) @      1.0000000000000000 from /Users/riccardo/ly2video.tmp/sani
**\* Warning: GenericResourceDir doesn't point to a valid resource directory.
               the -sGenericResourceDir=... option can be used to set this.

tised.ly:161:22
ly2video: (    37.8642071482220000,     39.1803851482220000) @      1.3750000000000000 from /Users/riccardo/ly2video.tmp/sanitised.ly:161:28
