### PR TITLE
Merge pull request #78 from thawk/fix_lilypond_2569

### DIFF
--- a/ly2video/cli.py
+++ b/ly2video/cli.py
@@ -223,6 +223,11 @@ def getLeftmostGrobsByMoment(output, dpi, leftPaperMarginPx):
     corresponds to the left-most grob at that moment.
     """
 
+    output = re.sub(
+        r"\n\*\*\* Warning: GenericResourceDir doesn't point to a valid resource directory\.\s*\n"
+        r"\s*the .+ option can be used to set this.\n\n",
+        "", output)
+
     lines = output.split('\n')
 
     leftmostGrobs = {}


### PR DESCRIPTION
Using re.sub() to remove unexpected warning in MacOS due to lilypond issue #2569