### PR TITLE
Fix #58 UTF-8 handling

### DIFF
--- a/ly2video/ly/tokenize.py
+++ b/ly2video/ly/tokenize.py
@@ -260,7 +260,7 @@ class Tokenizer(object):
         
         """
         def __new__(cls, matchObj, tokenizer):
-            obj = unicode.__new__(cls, matchObj.group())
+            obj = unicode.__new__(cls, matchObj.group(), "utf-8")
             obj.pos, obj.end = matchObj.span()
             return obj
 
@@ -293,7 +293,7 @@ class Tokenizer(object):
         
         """
         def __new__(cls, value, pos):
-            obj = unicode.__new__(cls, value)
+            obj = unicode.__new__(cls, value, "utf-8")
             obj.pos = pos
             obj.end = pos + len(obj)
             return obj


### PR DESCRIPTION
As said in the _LilyPond — Notation Reference v2.18.2 (stable-branch)_ -> _3.3.3 Special characters_ -> _Text encoding_, ``.ly`` files use UTF-8 encoding.  So we can alway use UTF-8 to parse ``.ly`` files.:

> LilyPond uses the character repertoire defined by the Unicode consortium and ISO/IEC 10646. This defines a unique name and code point for the character sets used in virtually all modern languages and many others too. Unicode can be implemented using several different encodings. LilyPond uses the UTF-8 encoding (UTF stands for Unicode Transformation Format) which represents all common Latin characters in one byte, and represents other characters using a variable length format of up to four bytes.
