### PR TITLE
Compatible with python2/3

### DIFF
--- a/ly2video/ly/__init__.py
+++ b/ly2video/ly/__init__.py
@@ -93,7 +93,7 @@ def headers(i18nFunc=None):
         ('tagline',     i18n("Tagline")),
     )
 
-headerNames = zip(*headers())[0] # puvodne zip(*headers())[0]
+headerNames = list(zip(*headers()))[0] # puvodne zip(*headers())[0]
 
 def modes(i18nFunc=None):
     i18n = i18nFunc or (lambda s: s)

--- a/ly2video/ly/pitch.py
+++ b/ly2video/ly/pitch.py
@@ -240,9 +240,9 @@ pitchInfo['catalan'] = pitchInfo['italiano']
 
 
 pitchWriter = dict(
-    (lang, PitchWriter(*data)) for lang, data in pitchInfo.iteritems())
+    (lang, PitchWriter(*data)) for lang, data in pitchInfo.items())
 
 pitchReader = dict(
-    (lang, PitchReader(*data)) for lang, data in pitchInfo.iteritems())
+    (lang, PitchReader(*data)) for lang, data in pitchInfo.items())
 
 

--- a/ly2video/ly/tokenize.py
+++ b/ly2video/ly/tokenize.py
@@ -79,9 +79,11 @@ subclass the Parser classes.
 """
 
 import re
-import rx
-import pitch
-import words
+import sys
+from six import add_metaclass
+from . import rx
+from . import pitch
+from . import words
 
 
 def _make_re(classes):
@@ -123,6 +125,7 @@ class _tokenizer_meta(type):
                     setattr(cls, name, type(name, (attr,), {'pattern': pattern}))
 
 
+@add_metaclass(_tokenizer_meta)
 class Tokenizer(object):
     """An environment to parse LilyPond text input.
     
@@ -133,7 +136,6 @@ class Tokenizer(object):
     - Subclasses of Parser: container with regex to parse LilyPond input.
     
     """
-    __metaclass__ = _tokenizer_meta
     
     def __init__(self, parserClass = None):
         self.reset(parserClass)
@@ -250,7 +252,7 @@ class Tokenizer(object):
     
     # Classes that represent pieces of lilypond text:
     # base classes:
-    class Token(unicode):
+    class Token(unicode if sys.version_info[0] < 3 else str):
         """Represents a parsed piece of LilyPond text.
         
         The subclass determines the type.
@@ -260,7 +262,11 @@ class Tokenizer(object):
         
         """
         def __new__(cls, matchObj, tokenizer):
-            obj = unicode.__new__(cls, matchObj.group(), "utf-8")
+            if sys.version_info[0] < 3:
+                obj = unicode.__new__(cls, matchObj.group(), "utf-8")
+            else:
+                obj = str.__new__(cls, matchObj.group())
+
             obj.pos, obj.end = matchObj.span()
             return obj
 
@@ -293,7 +299,11 @@ class Tokenizer(object):
         
         """
         def __new__(cls, value, pos):
-            obj = unicode.__new__(cls, value, "utf-8")
+            if sys.version_info[0] < 3:
+                obj = unicode.__new__(cls, value, "utf-8")
+            else:
+                obj = str.__new__(cls, value)
+
             obj.pos = pos
             obj.end = pos + len(obj)
             return obj

--- a/ly2video/ly/tools.py
+++ b/ly2video/ly/tools.py
@@ -23,8 +23,8 @@ from __future__ import unicode_literals
 All kinds of tools needed to manipulate strings with LilyPond input.
 """
 
-import pitch as lypitch
-import tokenize
+from . import pitch as lypitch
+from . import tokenize
 
 
 class Pitch(lypitch.Pitch):
@@ -77,7 +77,7 @@ def relativeToAbsolute(text, start = 0, changes = None):
         def __iter__(self):
             return self
             
-        def next(self):
+        def __next__(self):
             token = next(tokens)
             while isinstance(token, (tokenizer.Space, tokenizer.Comment)):
                 token = next(tokens)
@@ -88,6 +88,8 @@ def relativeToAbsolute(text, start = 0, changes = None):
                 absolute()
                 token = next(tokens)
             return token
+
+        next = __next__
     
     source = gen()
     
@@ -358,7 +360,7 @@ def transpose(text, transposer, start = 0, changes = None):
         def __iter__(self):
             return self
             
-        def next(self):
+        def __next__(self):
             while True:
                 token = next(tokens)
                 if isinstance(token, (tokenizer.Space, tokenizer.Comment)):
@@ -388,6 +390,8 @@ def transpose(text, transposer, start = 0, changes = None):
                 else:
                     return token
     
+        next = __next__
+
     source = gen()
     
     def consume():

--- a/ly2video/synchro.py
+++ b/ly2video/synchro.py
@@ -22,7 +22,7 @@
 # For more information about this program, please visit
 # <https://github.com/aspiers/ly2video/>.
 
-from utils import *
+from .utils import *
 
 class TimeCode (Observable):
 

--- a/ly2video/utils.py
+++ b/ly2video/utils.py
@@ -34,10 +34,10 @@ def setDebug():
 
 def debug(text):
     if DEBUG:
-        print text
+        print(text)
 
 def progress(text):
-    print text
+    print(text)
 
 def stderr(text):
     sys.stderr.write(text + "\n")

--- a/ly2video/video.py
+++ b/ly2video/video.py
@@ -22,10 +22,16 @@
 # For more information about this program, please visit
 # <https://github.com/aspiers/ly2video/>.
 
-from synchro import *
-from utils import *
+from .synchro import *
+from .utils import *
 import os
 from PIL import Image
+
+# for compatible with python3, if xrange doesn't exists, use range instead
+try:
+    xrange
+except NameError:
+    xrange = range
 
 # Image manipulation functions
 
@@ -171,7 +177,7 @@ class VideoFrameWriter(object):
 
     def push (self, media):
         self.height += media.height
-	self.__medias.append(media)
+        self.__medias.append(media)
         self.__timecode.registerObserver(media)
 
     @property

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Pillow==6.2.0
+six==1.14.0
 
 # python-midi 0.2.2 is also required; however, the upstream repository
 # still has an unmerged pull request fixing a significant tempo
@@ -7,7 +8,9 @@ Pillow==6.2.0
 #   https://github.com/vishnubob/python-midi/pull/6
 #
 # whereas my fork has the pull request already merged in:
-git+git://github.com/aspiers/python-midi.git#egg=midi
+#git+git://github.com/aspiers/python-midi.git#egg=midi;python_version<'3.0'
+git+git://github.com/vishnubob/python-midi.git#egg=midi;python_version<'3.0'
+git+git://github.com/vishnubob/python-midi.git@feature/python3#egg=midi;python_version>='3.0'
 
 # Once https://github.com/pypa/pip/pull/526 is completed,
 # this should work instead, for anyone who wants to


### PR DESCRIPTION
Using environment markers in requirements.txt to install suitable
branch of midi in python2/3. Modified the source code to compatible
with python2/3, and test for python 2.7.15 and 3.7.3.

I suggest to merge pillow-6..2.0 branch to master to easy following development.