### PR TITLE
Use standard temporary directory instead of current directory

### DIFF
--- a/ly2video/utils.py
+++ b/ly2video/utils.py
@@ -24,9 +24,11 @@
 
 import sys
 import os
+import tempfile
 
 DEBUG = False # --debug sets to True
 RUNDIR = ""
+TMPDIR = ""
 
 def setDebug():
     global DEBUG
@@ -89,7 +91,11 @@ def setRunDir (runDir):
     RUNDIR = runDir
 
 def tmpPath(*dirs):
-    segments = [ 'ly2video.tmp' ]
+    global TMPDIR
+    if not TMPDIR:
+        TMPDIR = tempfile.mkdtemp(prefix='ly2video')
+
+    segments = [ TMPDIR ]
     segments.extend(dirs)
     return os.path.join(RUNDIR, *segments)
 


### PR DESCRIPTION
Using a fixed ``ly2video.tmp`` under current directory make it impossible to start multiple process to convert multiple files at once.  Using standard ``tempfile`` module to get a unique temporary directory to avoid this.