### PR TITLE
Use ffmpeg to merget/concat videos.

### DIFF
--- a/ly2video/cli.py
+++ b/ly2video/cli.py
@@ -1139,6 +1139,7 @@ def generateNotesVideo(ffmpeg, fps, quality, wavPath):
         "-i", framePath,
         "-i", wavPath,
         "-q:v", quality,
+        "-f", "avi",
         notesPath
     ]
     safeRun(cmd, exitcode=15)
@@ -1175,6 +1176,7 @@ def generateSilentVideo(ffmpeg, fps, quality, desiredDuration, name, srcFrame):
         "-i", framePath,
         "-i", silentAudio,
         "-q:v", quality,
+        "-f", "avi",
         out
     ]
     safeRun(cmd, exitcode=14)
@@ -1229,6 +1231,7 @@ def generateVideo(ffmpeg, options, wavPath, titleText, finalFrame, outputFile):
             "-i", "concat:%s" % "|".join(videos),
             "-codec", "copy",
             "-y",
+            "-f", "avi",
             outputFile,
         ]
         safeRun(cmd, exitcode=16)

--- a/ly2video/cli.py
+++ b/ly2video/cli.py
@@ -1219,16 +1219,19 @@ def generateVideo(ffmpeg, options, wavPath, titleText, finalFrame, outputFile):
         progress("Joining videos:\n%s" %
                  "".join(["  %s\n" % video for video in videos]))
 
-        with open(outputFile,'wb') as wfd:
-            for video in videos:
-                with open(video,'rb') as fd:
-                    shutil.copyfileobj(fd, wfd)
-
-    # Could also do this with ffmpeg:
-    #
-    #   ffmpeg -i concat:"title.mpg|notes.mpg" -codec copy out.mpg
-    #
-    # See: http://stackoverflow.com/questions/7333232/concatenate-two-mp4-files-using-ffmpeg
+        # Do this with ffmpeg:
+        #
+        #   ffmpeg -i concat:"title.mpg|notes.mpg" -codec copy out.mpg
+        #
+        # See: http://stackoverflow.com/questions/7333232/concatenate-two-mp4-files-using-ffmpeg
+        cmd = [
+            ffmpeg,
+            "-i", "concat:%s" % "|".join(videos),
+            "-codec", "copy",
+            "-y",
+            outputFile,
+        ]
+        safeRun(cmd, exitcode=16)
 
 
 def getLyVersion(fileName):


### PR DESCRIPTION
It seems that just concat video files into one not work as expected, at least on my MacOS.  The final video file has the same duration with ``note.mpg``.

So I change to the ffmpeg suggested in the original comment.