### PR TITLE
Pipe images to ffmpeg to speed up a lot

### DIFF
--- a/ly2video/cli.py
+++ b/ly2video/cli.py
@@ -1152,6 +1152,7 @@ def generateNotesVideo(ffmpeg, fps, quality, frames, wavPath):
     notesPath = tmpPath("notes.mpg")
     cmd = [
         ffmpeg,
+        "-nostdin",
         "-f", "image2pipe",
         "-r", str(fps),
         "-i", "-",
@@ -1174,6 +1175,7 @@ def generateSilentVideo(ffmpeg, fps, quality, desiredDuration, name, srcFrame):
     silentAudio = generateSilence(name, trueDuration)
     cmd = [
         ffmpeg,
+        "-nostdin",
         "-f", "image2pipe",
         "-r", str(fps),
         "-i", "-",
@@ -1231,6 +1233,7 @@ def generateVideo(ffmpeg, options, wavPath, titleText, frameWriter, outputFile):
         # See: http://stackoverflow.com/questions/7333232/concatenate-two-mp4-files-using-ffmpeg
         cmd = [
             ffmpeg,
+            "-nostdin",
             "-i", "concat:%s" % "|".join(videos),
             "-codec", "copy",
             "-y",

--- a/ly2video/video.py
+++ b/ly2video/video.py
@@ -414,7 +414,7 @@ class ScoreImage (Media):
             centre = self.width / 2
             left  = int(index - centre)
             right = int(index + centre)
-            frame = self.picture.copy().crop((left, self.__cropTop, right, self.__cropBottom))
+            frame = self.picture.crop((left, self.__cropTop, right, self.__cropBottom))
             cursorX = centre
         else:
             if self.__leftEdge is None:
@@ -435,7 +435,7 @@ class ScoreImage (Media):
                 # the cursor has to finish its travel in the last picture cropping
                 self.rightMargin = 0
             rightEdge = self.__leftEdge + self.width
-            frame = self.picture.copy().crop((self.__leftEdge, self.__cropTop,
+            frame = self.picture.crop((self.__leftEdge, self.__cropTop,
                                           rightEdge, self.__cropBottom))
         return (frame,cursorX)
 

--- a/ly2video/video.py
+++ b/ly2video/video.py
@@ -177,6 +177,9 @@ class VideoFrameWriter(object):
         self.__medias = []
         self.__timecode = TimeCode (midiTicks,temposList,midiResolution,fps)
 
+        self.firstFrame = None
+        self.lastFrame = None
+
     def push (self, media):
         self.height += media.height
         self.__medias.append(media)
@@ -194,25 +197,34 @@ class VideoFrameWriter(object):
         self.__scoreImage.cursorLineColor = self.cursorLineColor
         self.__timecode.registerObserver(scoreImage)
 
+    @property
+    def frames (self):
+        while not self.__timecode.atEnd() :
+            neededFrames = self.__timecode.nbFramesToNextNote()
+            for i in xrange(neededFrames):
+                frame = self.__makeFrame(i, neededFrames)
+                if i == 0:
+                    self.firstFrame = frame
+
+                self.frameNum += 1
+                yield frame
+            else:
+                self.lastFrame = frame
+
+            self.__timecode.goToNextNote()
+
     def write (self):
         # folder to store frames for video
         if not os.path.exists("notes"):
             os.mkdir("notes")
 
-        while not self.__timecode.atEnd() :
-            neededFrames = self.__timecode.nbFramesToNextNote()
-            for i in xrange(neededFrames):
-                videoFrame = self.__makeFrame(i, neededFrames)
-                # Save the frame.  ffmpeg doesn't work if the numbers in these
-                # filenames are zero-padded.
-                videoFrame.save(tmpPath("notes", "frame%d.png" % self.frameNum))
-                self.frameNum += 1
-                if not DEBUG and self.frameNum % 10 == 0:
-                    sys.stdout.write(".")
-                    sys.stdout.flush()
-
-            self.__timecode.goToNextNote()
-
+        for videoFrame in self.frames:
+            # Save the frame.  ffmpeg doesn't work if the numbers in these
+            # filenames are zero-padded.
+            videoFrame.save(tmpPath("notes", "frame%d.png" % self.frameNum))
+            if not DEBUG and self.frameNum % 10 == 0:
+                sys.stdout.write(".")
+                sys.stdout.flush()
 
     def __makeFrame (self, numFrame, among):
         debug("        writing frame %d" % (self.frameNum))

--- a/ly2video/video.py
+++ b/ly2video/video.py
@@ -203,7 +203,7 @@ class VideoFrameWriter(object):
             neededFrames = self.__timecode.nbFramesToNextNote()
             for i in xrange(neededFrames):
                 frame = self.__makeFrame(i, neededFrames)
-                if i == 0:
+                if not self.firstFrame:
                     self.firstFrame = frame
 
                 self.frameNum += 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Pillow==6.2.0
+pexpect==4.8.0
 
 # python-midi 0.2.2 is also required; however, the upstream repository
 # still has an unmerged pull request fixing a significant tempo


### PR DESCRIPTION
After profiling using cProfile, it seems that most time is used to compress images into PNG format.

Orignal time:

```
87.53s user 2.42s system 125% cpu 1:11.65 total
```

Use BMP format instead of PNG can reduce most time:

```
24.09s user 5.17s system 145% cpu 20.075 total
```

Using BMP format can reduce CPU time, but it use much more disk space (22MBps per image file).  So I use ``ffmpeg -f image2pipe`` insted of ``ffmpeg -f image2`` to pipe images to ffmpeg, avoid writing to disk.  Because the ``subprocess`` module doesn't support multiple write to stdin, so I introduce ``pexpect`` module to pipe multiple images one by one to ffmpeg.  After that, the CPU time is:

```
25.96s user 3.93s system 192% cpu 15.529 total
```

After removing unnecessary ``copy()``, the total time is reduced one more second:

```
24.97s user 3.53s system 200% cpu 14.212 total
```

I have test it on MacOS for python2 and python3.