### PR TITLE
Port to Python 3

### DIFF
--- a/Dockerfile.ly2video
+++ b/Dockerfile.ly2video
@@ -2,8 +2,9 @@ FROM ubuntu:16.04
 
 RUN apt-get update && apt-get install -y \
     timidity \
-    python-pip \
-    python-imaging swig \
+    python3-pip \
+    python3-pil \
+    swig \
     libasound-dev \
     git \
     curl \
@@ -39,8 +40,8 @@ COPY . .
 RUN pwd
 RUN ls
 
-RUN pip install -r requirements.txt
-RUN pip install .
+RUN pip3 install -r requirements.txt
+RUN pip3 install .
 
 WORKDIR ${SCORE_PATH}
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ to get it working - please see below for how to get support.
 *   FFmpeg (if you are on Ubuntu or Debian, see first see
     [issue 32](https://github.com/aspiers/ly2video/issues/32))
 *   TiMidity++
-*   Python 3.5
+*   Python >= 3.5
 *   Python's [pip installer](http://www.pip-installer.org)
 *   [swig](http://www.swig.org/) and ALSA development libraries
     (`python-midi` requires these in order to build its sequencer

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ to get it working - please see below for how to get support.
 *   FFmpeg (if you are on Ubuntu or Debian, see first see
     [issue 32](https://github.com/aspiers/ly2video/issues/32))
 *   TiMidity++
-*   Python 2.7 (please note Python 3 is not yet supported!)
+*   Python 3.5
 *   Python's [pip installer](http://www.pip-installer.org)
 *   [swig](http://www.swig.org/) and ALSA development libraries
     (`python-midi` requires these in order to build its sequencer

--- a/ly2video/cli.py
+++ b/ly2video/cli.py
@@ -416,7 +416,7 @@ def getNotesInTicks(midiFile):
     pitchBends   = {}
 
     # for every channel in MIDI (except the first one)
-    for i in xrange(1, len(midiFile)):
+    for i in range(1, len(midiFile)):
         debug("Reading MIDI track %d" % i)
         track = midiFile[i]
         pendingPitchBend = None
@@ -963,7 +963,7 @@ def getVersion():
             return m.group(1)
     except:
         #exc_type, exc_value, exc_traceback = sys.exc_info()
-        #print "%s: %s" % (exc_type.__name__, exc_value)
+        #print("%s: %s" % (exc_type.__name__, exc_value))
         pass
 
     return VERSION

--- a/ly2video/cli.py
+++ b/ly2video/cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding=utf-8
 
 # ly2video - generate performances video from LilyPond source files

--- a/ly2video/cli.py
+++ b/ly2video/cli.py
@@ -25,15 +25,12 @@
 # Used to determine --version output for released versions, not
 # when running from a git check-out:
 
-import collections
-import copy
 import itertools
 import os
 import re
 import shutil
 import subprocess
 import sys
-import urllib
 import pipes
 from collections import namedtuple
 from distutils.version import StrictVersion
@@ -88,7 +85,7 @@ class LySrcLocation(object):
     Addtional pitch info is stored.
 
     - octave: int, 0 is c', 1 is c'', -1 is c, and so on
-    - notename: int, 0,1,2,3,4,5,6 for c,d,e,f,g,a,b 
+    - notename: int, 0,1,2,3,4,5,6 for c,d,e,f,g,a,b
     - alteration: Fraction, 0: no alteration, 1/2: SHARP, -1/2: FLAT, and so on
 
     """
@@ -1144,7 +1141,7 @@ def getOutputFile(options):
 def imageToBytes(image):
     f = BytesIO()
     image.save(f, format="BMP")
-    return f.getvalue() 
+    return f.getvalue()
 
 
 def generateNotesVideo(ffmpeg, fps, quality, frames, wavPath):
@@ -1538,7 +1535,7 @@ def main():
 
     numStaffLines = getNumStaffLines(lyFile, options.dpi)
 
-    titleText = collections.namedtuple("titleText", "name author")
+    titleText = namedtuple("titleText", "name author")
     titleText.name = "<name of song>"
     titleText.author = "<author>"
 

--- a/ly2video/synchro.py
+++ b/ly2video/synchro.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding=utf-8
 
 # ly2video - generate performances video from LilyPond source files

--- a/ly2video/utils.py
+++ b/ly2video/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding=utf-8
 
 # ly2video - generate performances video from LilyPond source files

--- a/ly2video/video.py
+++ b/ly2video/video.py
@@ -39,7 +39,7 @@ except NameError:
 
 def writeCursorLine(image, X, color):
     """Draws a line on the image"""
-    for pixel in xrange(image.size[1]):
+    for pixel in range(image.size[1]):
         image.putpixel((X    , pixel), color)
         image.putpixel((X + 1, pixel), color)
 
@@ -49,7 +49,7 @@ def writeMeasureCursor(image, start, end, color, cursor_height=10):
     if start > w :
         raise Exception()
     for dx in range(end-start) :
-        for y in xrange(cursor_height):
+        for y in range(cursor_height):
             if start + dx < w and start + dx > 0 :
                 image.putpixel((start + dx, h-y-1), color)
 
@@ -71,9 +71,9 @@ def findTopStaffLine(image, lineLength):
     width, height = image.size
 
     # Start searching at the hard left but allow for a left margin.
-    for x in xrange(width):
-        for y in xrange(height):
-            for length in xrange(lineLength):
+    for x in range(width):
+        for y in range(height):
+            for length in range(lineLength):
                 # testing color of pixels in range (startPos, startPos + lineLength)
                 if image.getpixel((x + length, y)) == (255,255,255):
                     # if it's white then it's not a staff line
@@ -113,7 +113,7 @@ def findStaffLinesInImage(image, lineLength):
 
     width, height = image.size
 
-    for y in xrange(firstLineY, height):
+    for y in range(firstLineY, height):
         # if color of that pixel isn't white
         if image.getpixel((firstLineX, y)) != (255,255,255):
             # and it can be new staff line
@@ -201,7 +201,7 @@ class VideoFrameWriter(object):
     def frames (self):
         while not self.__timecode.atEnd() :
             neededFrames = self.__timecode.nbFramesToNextNote()
-            for i in xrange(neededFrames):
+            for i in range(neededFrames):
                 frame = self.__makeFrame(i, neededFrames)
                 if not self.firstFrame:
                     self.firstFrame = frame
@@ -463,7 +463,7 @@ class ScoreImage (Media):
         Returns True if the line with the given y coordinate
         is entirely white.
         """
-        for x in xrange(width):
+        for x in range(width):
             if pixels[x, y] != (255, 255, 255):
                 return False
         return True
@@ -474,7 +474,7 @@ class ScoreImage (Media):
         pixels = self.__picture.load()
         progress("Auto-detecting top margin; this may take a while ...")
         self.__topCroppable = 0
-        for y in xrange(picture_height):
+        for y in range(picture_height):
             if y == picture_height - 1:
                 raise BlankScoreImageError
             if self.__isLineBlank(pixels, picture_width, y):
@@ -488,7 +488,7 @@ class ScoreImage (Media):
         pixels = self.__picture.load()
         progress("Auto-detecting top margin; this may take a while ...")
         self.__bottomCroppable = 0
-        for y in xrange(picture_height - 1, -1, -1):
+        for y in range(picture_height - 1, -1, -1):
             if y == 0:
                 raise BlankScoreImageError
             if self.__isLineBlank(pixels, picture_width, y):

--- a/ly2video/video.py
+++ b/ly2video/video.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding=utf-8
 
 # ly2video - generate performances video from LilyPond source files
@@ -34,7 +34,7 @@ try:
 except NameError:
     xrange = range
 
- 
+
 # Image manipulation functions
 
 def writeCursorLine(image, X, color):

--- a/scripts/midi-rubato
+++ b/scripts/midi-rubato
@@ -33,7 +33,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import re
 import sys
 
 from optparse import OptionParser

--- a/scripts/midi-rubato
+++ b/scripts/midi-rubato
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 midi-rubato - inserts tempo change events into a .midi file

--- a/scripts/xsc2beatmap
+++ b/scripts/xsc2beatmap
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 xsc2beatmap - generates a beat map from an .xsc file

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 from setuptools import setup
 

--- a/test.py
+++ b/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding=utf-8
 
 # ly2video - generate performances video from LilyPond source files

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 minversion = 1.8
-envlist = py27,pep8
+envlist = py35,pep8
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Thanks to https://github.com/aspiers/python-midi/pull/1 and https://github.com/aspiers/python-midi/pull/2, ly2video already works fine with Python 3 (I'm using it with no issue on my [Docker image](https://hub.docker.com/r/jeandeaual/lilypond)).

This PR drops support for Python 2 and updates `Dockerfile.ly2video` to use Python 3.

I set the minimum Python version to 3.5 since that's what's available on the Docker image (Ubuntu 16.04).

Closes #11.