### PR TITLE
Prevent possible DecompressionBombError with Pillow >= 5.0.0

### DIFF
--- a/ly2video/cli.py
+++ b/ly2video/cli.py
@@ -1595,6 +1595,8 @@ def main():
     leftMargin, rightMargin = options.cursorMargins.split(",")
     frameWriter.scoreImage = ScoreImage(
         options.width, options.height,
+        # https://pillow.readthedocs.io/en/5.1.x/releasenotes/5.0.0.html#decompression-bombs-now-raise-exceptions
+        Image.MAX_IMAGE_PIXELS = None
         Image.open(notesImage), noteIndices, measuresXpositions,
         int(leftMargin), int(rightMargin),
         options.scrollNotes, options.noteCursor)


### PR DESCRIPTION
In one of my GitHub Action running ly2video, I got the following error with a medium size LilyPond file:

```
Generating PNG and MIDI files ...
------------------------------------------------------------
------------------------------------------------------------
Generated PNG and MIDI files
Looking for staff lines in converted.preview.png
First staff line found at (27, 307)
Found 2 staff lines
Margins in mm: left=17 top=30 right=17 bottom=30
Margins in px: left=200 top=360 right=200 bottom=360
Margins in mm: left=17 top=30 right=17 bottom=30
Margins in px: left=200 top=360 right=200 bottom=360
Wrote sanitised version of /tmp/ly2video52elvx5c/converted.ly into /tmp/ly2video52elvx5c/sanitised.ly
Generating PNG and MIDI files ...
------------------------------------------------------------
------------------------------------------------------------
Generated PNG and MIDI files
------------------------------------------------------------
MIDI resolution (ticks per beat) is 384
------------------------------------------------------------
MIDI: Parsing MIDI file has ended.
------------------------------------------------------------
    WARNING: skipping MIDI tick 215424 since no grob matched; contents:
        pitch 38 length 2
        pitch 38 length 2
sync points found:   920
             from:   921 original indices
              and:   922 original ticks
   last tick used:   920
    ticks skipped:     1
------------------------------------------------------------
SYNC: ly2video will generate approx. 16228 frames at 30.000 frames/sec.
Writing frames ...
A dot is displayed for every 10 frames generated.
    sys.exit(main())
  File "/usr/local/lib/python3.9/dist-packages/ly2video/cli.py", line 1598, in main
    Image.open(notesImage), noteIndices, measuresXpositions,
  File "/usr/local/lib/python3.9/dist-packages/PIL/Image.py", line 2881, in open
    im = _open_core(fp, filename, prefix)
  File "/usr/local/lib/python3.9/dist-packages/PIL/Image.py", line 2868, in _open_core
    _decompression_bomb_check(im.size)
  File "/usr/local/lib/python3.9/dist-packages/PIL/Image.py", line 2791, in _decompression_bomb_check
    raise DecompressionBombError(
PIL.Image.DecompressionBombError: Image size (189218012 pixels) exceeds limit of 178956970 pixels, could be decompression bomb DOS attack.
```

This seems to be caused by [a warning that was upgraded to an exception in Pillow 5.0.0](https://pillow.readthedocs.io/en/5.1.x/releasenotes/5.0.0.html#decompression-bombs-now-raise-exceptions), thus related to #77.

Setting `Image.MAX_IMAGE_PIXELS` to `None` prevents this exception from happening. Since all PNG images are generated by LilyPond, this might not be a security risk?