### PR TITLE
Move the call to Image.MAX_IMAGE_PIXELS

### DIFF
--- a/ly2video/cli.py
+++ b/ly2video/cli.py
@@ -1533,6 +1533,9 @@ def main():
     # version, try to convert it
     lyFile = preprocessLyFile(lyFile, lilypondVersion, dumper)
 
+    # https://pillow.readthedocs.io/en/5.1.x/releasenotes/5.0.0.html#decompression-bombs-now-raise-exceptions
+    Image.MAX_IMAGE_PIXELS = None
+
     numStaffLines = getNumStaffLines(lyFile, options.dpi)
 
     titleText = namedtuple("titleText", "name author")
@@ -1595,8 +1598,6 @@ def main():
     leftMargin, rightMargin = options.cursorMargins.split(",")
     frameWriter.scoreImage = ScoreImage(
         options.width, options.height,
-        # https://pillow.readthedocs.io/en/5.1.x/releasenotes/5.0.0.html#decompression-bombs-now-raise-exceptions
-        Image.MAX_IMAGE_PIXELS = None
         Image.open(notesImage), noteIndices, measuresXpositions,
         int(leftMargin), int(rightMargin),
         options.scrollNotes, options.noteCursor)


### PR DESCRIPTION
Sorry, I didn't notice this issue in #95.
Since there's a call to Image.open in getNumStaffLines, place Image.MAX_IMAGE_PIXELS before.