### PR TITLE
[WIP] use mido instead of python-midi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ RUN apt-get update && apt-get install -y \
     timidity \
     python3-pip \
     python3-pil \
-    swig \
-    libasound-dev \
     git \
     curl \
     ffmpeg \

--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ to get it working - please see below for how to get support.
 *   TiMidity++
 *   Python >= 3.5
 *   Python's [pip installer](http://www.pip-installer.org)
-*   [swig](http://www.swig.org/) and ALSA development libraries
-    (`python-midi` requires these in order to build its sequencer
-    code successfully, although ly2video doesn't use that code)
 
 ## Installation
 
@@ -71,7 +68,7 @@ of LilyPond, so you might need to install a newer one via the
 You can ensure the remaining dependencies are installed via something
 like:
 
-    sudo apt-get install timidity python3-pip python3-pil swig libasound-dev
+    sudo apt-get install timidity python3-pip python3-pil
 
 ### Installing dependencies on Arch-based Linux distributions
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,3 @@
 Pillow==9.3.0
 pexpect==4.8.0
-
-# python-midi 0.2.2 is also required; however, the upstream repository
-# still has an unmerged pull request fixing a significant tempo
-# calculation bug:
-#
-#   https://github.com/vishnubob/python-midi/pull/6
-#
-# whereas my fork has the pull request already merged in:
-git+https://github.com/aspiers/python-midi.git#egg=midi
-
-# Once https://github.com/pypa/pip/pull/526 is completed,
-# this should work instead, for anyone who wants to
-# concurrently hack on python-midi:
-#-e git+https://github.com/aspiers/python-midi.git#egg=midi&subdirectory=src
+mido==1.2.9

--- a/scripts/midi-rubato
+++ b/scripts/midi-rubato
@@ -37,7 +37,7 @@ import sys
 
 from optparse import OptionParser
 
-import midi
+import mido
 
 def parse_args():
     parser = OptionParser("Usage: %prog SRC-MIDI BEATMAP DST-MIDI")
@@ -56,6 +56,27 @@ def parse_args():
 def main():
     src, beatmap, dst = parse_args()
     generate_adjusted_midi_file(src, dst, beatmap)
+
+def make_time_abs(midiFile):
+    """
+    Changes the time of all messages to absolute time in ticks
+    """
+    for track in midiFile.tracks:
+        time = 0
+        for event in track:
+            time += event.time
+            event.time = time
+
+def make_time_rel(midiFile):
+    """
+    Changes the time of all messages to incremental time in ticks
+    """
+    for track in midiFile.tracks:
+        prev_time = 0
+        for event in track:
+            tmp_time = event.time
+            event.time -= prev_time
+            prev_time = tmp_time
 
 def get_tempos_from_beatmap(filename, resolution):
     xsc = open(filename)
@@ -81,11 +102,9 @@ def get_tempos_from_beatmap(filename, resolution):
 def new_tempo_event(tick, new_bpm, new_qpm, section, measure, beat):
     print("inserting %6.2fbpm (%6.2fqpm) @ section %d bar %3d beat %d tick %6d" %
           (new_bpm, new_qpm, section, measure, beat, tick))
-    tc = midi.SetTempoEvent()
-    tc.tick = tick
+    tc = mido.MetaMessage('set_tempo', time=tick, tempo=mido.bpm2tempo(new_qpm))
     # N.B. the midi library's API incorrectly refers to bpm when
     # it actually means qpm:
-    tc.set_bpm(new_qpm)
     return tc
 
 def apply_rubato(tracks, tempos):
@@ -97,7 +116,7 @@ def apply_rubato(tracks, tempos):
     # never know).
     for i in xrange(len(control)):
         event = control[i]
-        if isinstance(event, midi.EndOfTrackEvent):
+        if event.type == 'end_of_track':
             del control[i:]
             break
 
@@ -112,14 +131,14 @@ def apply_rubato(tracks, tempos):
                 break
             next_tempo = tempos[0]
             next_tempo_tick = next_tempo[0]
-            if next_tempo_tick > event.tick:
+            if next_tempo_tick > event.time:
                 break
             tc = new_tempo_event(*(tempos.pop(0)))
             control.insert(event_index, tc)
             event_index += 1
 
         # remove any pre-existing SetTempoEvents
-        if isinstance(event, midi.SetTempoEvent):
+        if event.type == 'set_tempo':
             print("  - dropping SetTempoEvent")
             del control[event_index]
         else:
@@ -135,18 +154,15 @@ def apply_rubato(tracks, tempos):
         tc = new_tempo_event(*(tempos.pop(0)))
         control.append(tc)
 
-    eot = midi.EndOfTrackEvent()
-    eot.tick = control[-1].tick
+    eot = mido.MetaMessage('end_of_track', time=control[-1].time)
     control.append(eot)
-
-    return tracks
 
 def get_final_tick(tracks):
     final_tick = None
     for track in tracks:
         for event in track:
-            if event.tick > final_tick:
-                final_tick = event.tick
+            if event.time > final_tick:
+                final_tick = event.time
     return final_tick
 
 def timestamp_to_secs(timestamp):
@@ -164,18 +180,18 @@ def secs_to_timestamp(secs):
     return "%d:%02d:%s" % (hours, mins, secs)
 
 def generate_adjusted_midi_file(src, dst, beatmap):
-    tracks = midi.read_midifile(src)
+    midiFile = mido.MidiFile(src)
     print("Read from %s" % src)
 
-    tracks.make_ticks_abs()
-    beats = get_tempos_from_beatmap(beatmap, tracks.resolution)
-    apply_rubato(tracks, beats)
+    make_time_abs(midiFile)
+    beats = get_tempos_from_beatmap(beatmap, midiFile.ticks_per_beat)
+    apply_rubato(midiFile.tracks, beats)
     from pprint import pprint
-    pprint(tracks[0][-2])
-    pprint(tracks[1][-2])
-    tracks.make_ticks_rel()
+    pprint(midiFile.tracks[0][-2])
+    pprint(midiFile.tracks[1][-2])
+    make_time_rel(midiFile)
 
-    midi.write_midifile(dst, tracks)
+    midiFile.save(dst)
     print("Wrote tempo-adjusted tracks to %s" % dst)
 
 if __name__ == '__main__':


### PR DESCRIPTION
As python-midi isn't maintained, needs swig/alsa bloat and didn't want to install for me I've replaced python-midi with [mido](https://pypi.org/project/mido/), which is available on more systems and doesn't need swig/alsa.

I tested with a simple lilypond file, what still needs to be tested:
- midi file containing pitchbend messages (microtonal?)
- midi-rubato script

Can you or someone else test those cases? Or supply some test files for these cases?

Thanks for the project, very useful!