### PR TITLE
Fix python-midi cloning error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@ pexpect==4.8.0
 #   https://github.com/vishnubob/python-midi/pull/6
 #
 # whereas my fork has the pull request already merged in:
-git+git://github.com/aspiers/python-midi.git#egg=midi
+git+https://github.com/aspiers/python-midi.git#egg=midi
 
 # Once https://github.com/pypa/pip/pull/526 is completed,
 # this should work instead, for anyone who wants to
 # concurrently hack on python-midi:
-#-e git+git://github.com/aspiers/python-midi.git#egg=midi&subdirectory=src
+#-e git+https://github.com/aspiers/python-midi.git#egg=midi&subdirectory=src


### PR DESCRIPTION
When running `pip install -r requirements.txt`, the following issue occurs:

```
Collecting midi
  Cloning git://github.com/aspiers/python-midi.git to /private/var/folders/2j/w7_gs4115s16037ht79tl29w_7hx9z/T/pip-install-l6axk901/midi_74095e4e9d504afb98672aca4bccb5b4
  Running command git clone --filter=blob:none --quiet git://github.com/aspiers/python-midi.git /private/var/folders/2j/w7_gs4115s16037ht79tl29w_7hx9z/T/pip-install-l6axk901/midi_74095e4e9d504afb98672aca4bccb5b4
  fatal: read error: Operation timed out
  error: subprocess-exited-with-error
```

As mentioned in [this blog post](https://github.blog/2021-09-01-improving-git-protocol-security-github/), support for the unencrypted Git protocol was removed on January 11, 2022.