### PR TITLE
Improve scroll-notes mode

### DIFF
--- a/ly2video/cli.py
+++ b/ly2video/cli.py
@@ -77,6 +77,16 @@ NOTE_ALTERATIONS = [
     'eses', 'eseh', 'es', 'eh', '', 'ih', 'is', 'isih', 'isis'
 ]
 
+class Range(object):
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+
+    def __eq__(self, other):
+        return self.start <= other <= self.end
+
+    def __repr__(self):
+        return '[{0},{1}]'.format(self.start, self.end)
 
 class LySrcLocation(object):
     """
@@ -847,8 +857,8 @@ def parseOptions():
         "-s", "--scroll-notes", dest="scrollNotes",
         help='rather than scrolling the cursor from left to right, '
         'scroll the notation from right to left and keep the '
-        'cursor in the centre',
-        action="store_true", default=False)
+        'cursor in the specified horizontal position (0-1)',
+        type=float, metavar="POS", default=None, choices=[Range(0.0, 1.0)])
 
     group_video = parser.add_argument_group(title='Video output')
 

--- a/ly2video/video.py
+++ b/ly2video/video.py
@@ -414,8 +414,16 @@ class ScoreImage (Media):
             centre = self.width / 2
             left  = int(index - centre)
             right = int(index + centre)
-            frame = self.picture.crop((left, self.__cropTop, right, self.__cropBottom))
             cursorX = int(centre)
+            cropped = self.picture.crop((max(left, 0), self.__cropTop,
+                                         min(picture_width, right), self.__cropBottom))
+
+            if left < 0 or right > picture_width:
+                # Paste the cropped frame onto white background
+                frame = Image.new('RGB', (self.width, self.height), (255, 255, 255))
+                frame.paste(cropped, (max(-left, 0), 0))
+            else:
+                frame = cropped
         else:
             if self.__leftEdge is None:
                 # first frame

--- a/ly2video/video.py
+++ b/ly2video/video.py
@@ -279,7 +279,7 @@ class ScoreImage (Media):
     This class handles the 'measure cursor', a new type of cursor.
     """
 
-    def __init__ (self, width, height, picture, notesXpostions, measuresXpositions, leftMargin = 50, rightMargin = 50, scrollNotes = False, noteCursor = True):
+    def __init__ (self, width, height, picture, notesXpostions, measuresXpositions, leftMargin = 50, rightMargin = 50, scrollNotes = None, noteCursor = True):
         """
         Params:
           - width:             pixel width of frames (and video)
@@ -411,10 +411,9 @@ class ScoreImage (Media):
 
         if self.scrollNotes:
             # Get frame from image of staff
-            centre = self.width / 2
-            left  = int(index - centre)
-            right = int(index + centre)
-            cursorX = int(centre)
+            cursorX = int(self.width * self.scrollNotes)
+            left  = int(index - cursorX)
+            right = int(index - cursorX + self.width)
             cropped = self.picture.crop((max(left, 0), self.__cropTop,
                                          min(picture_width, right), self.__cropBottom))
 


### PR DESCRIPTION
This PR adds two features to the `-s/--scroll-notes` mode:

- Paste the cropped staff onto white background instead of black background resulting implicitly from `Image.crop()`
- Allow specifying the horizontal position of the cursor like `-s 0.3`, to place the cursor at 30% of the width. Currently, the cursor is always placed in the middle.

Before:
[music_before.webm](https://github.com/user-attachments/assets/2ccbac69-857c-4419-92c8-3a845ab27e98)

After with `-s 0.3`:
[music_after.webm](https://github.com/user-attachments/assets/e3473bdd-ced8-4741-8517-7cc45007b844)
