### PR TITLE
Support TabStaff and TabVoice in dump-spacetime-info

### DIFF
--- a/ly2video/cli.py
+++ b/ly2video/cli.py
@@ -1391,6 +1391,14 @@ def writeSpaceTimeDumper():
     \override BarLine.after-line-breaking = #dump-spacetime-info-barline
   }
   \context {
+    \TabVoice
+    \override TabNoteHead.after-line-breaking = #dump-spacetime-info
+  }
+  \context {
+    \TabStaff
+    \override BarLine.after-line-breaking = #dump-spacetime-info-barline
+  }
+  \context {
     \Voice
     \override NoteHead.after-line-breaking = #dump-spacetime-info
   }


### PR DESCRIPTION
Fixes #123

Tabs use TabStaff and TabVoice contexts with TabNoteHead notes. Currently, the spacetime dumper is not producing any output for tabs alone.

Here's the output for the 3rd example from the [manual](https://lilypond.org/doc/v2.25/Documentation/notation/default-tablatures):
[test.webm](https://github.com/user-attachments/assets/30759d86-f46f-4404-ad83-a6a114c42ac0)
