### PR TITLE
Updated to work with latest Python 3.14

### DIFF
--- a/ly2video/__init__.py
+++ b/ly2video/__init__.py
@@ -1,6 +1,6 @@
-import pkg_resources
+import importlib.metadata
 
 try:
-    __version__ = pkg_resources.get_distribution(__name__).version
+    __version__ = importlib.metadata.version(__name__)
 except:
     __version__ = 'unknown'

--- a/ly2video/cli.py
+++ b/ly2video/cli.py
@@ -27,7 +27,7 @@
 
 import itertools
 import os
-import pipes
+import shlex
 import re
 import shutil
 import subprocess
@@ -35,7 +35,7 @@ import sys
 import traceback
 
 from collections import namedtuple
-from distutils.version import StrictVersion
+import packaging.version
 from argparse import ArgumentParser
 from struct import pack
 from fractions import Fraction
@@ -324,16 +324,13 @@ def generateTitleFrame(titleText, width, height, ttfFile):
     # font for author
     authorFont = ImageFont.truetype(ttfFile, int(height / 25))
 
-    # args - position of left upper corner of rectangle (around text),
+    # args - position of top middle of rectangle (around text),
     # text, font and color (black)
-    drawer.text(((width - nameFont.getsize(titleText.name)[0]) / 2,
-                 (height - nameFont.getsize(titleText.name)[1]) / 2 -
-                 height / 25),
-                titleText.name, font=nameFont, fill=(0, 0, 0))
+    drawer.text( ( width / 2, height / 2 - height / 25),
+                titleText.name, font=nameFont, fill=(0, 0, 0), anchor = "ms")
     # same thing
-    drawer.text(((width - authorFont.getsize(titleText.author)[0]) / 2,
-                 (height / 2) + height / 25),
-                titleText.author, font=authorFont, fill=(0, 0, 0))
+    drawer.text( (width / 2, (height / 2) + (height / 25)),
+                titleText.author, font=authorFont, fill=(0, 0, 0), anchor = "ms")
 
     return titleScreen
 
@@ -978,7 +975,7 @@ def getVersion():
     try:
         stdout = subprocess.check_output(["git", "describe", "--tags"],
                                          cwd=os.path.dirname(__file__))
-        m = re.match('^(v\d\S+)', stdout)
+        m = re.match(b'^(v\d\S+)', stdout)
         if m:
             return m.group(1)
     except:
@@ -1019,7 +1016,7 @@ def safeRun(cmd, errormsg=None, exitcode=None, shell=False, issues=[], preproces
     else:
         quotedCmd = [cmd[0]]
         for arg in cmd[1:]:
-            quotedCmd.append(pipes.quote(arg))
+            quotedCmd.append(shlex.quote(arg))
         quotedCmd = " ".join(quotedCmd)
 
     debug("Running: %s\n" % quotedCmd)
@@ -1048,7 +1045,7 @@ def safeRun(cmd, errormsg=None, exitcode=None, shell=False, issues=[], preproces
 def safeRunInput(cmd, inputs, errormsg=None, exitcode=None, issues=[], preprocessor=None):
     quotedCmd = [cmd[0]]
     for arg in cmd[1:]:
-        quotedCmd.append(pipes.quote(arg))
+        quotedCmd.append(shlex.quote(arg))
     quotedCmd = " ".join(quotedCmd)
 
     debug("Running: %s\n" % quotedCmd)
@@ -1106,7 +1103,7 @@ def findExecutableDependencies(options):
     #   https://code.google.com/p/lilypond/issues/detail?id=2570
     #   https://codereview.appspot.com/6248056/
     #   http://article.gmane.org/gmane.comp.gnu.lilypond.general/72373/
-    if StrictVersion(version) < StrictVersion('2.15.41'):
+    if packaging.version.parse(version) < packaging.version.parse('2.15.41'):
         fatal("You have LilyPond %s which does not support\n"
               "infinitely long lines.  Please upgrade to >= 2.15.41." %
               version)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
-Pillow==9.3.0
-pexpect==4.8.0
-mido==1.2.9
+mido==1.3.3
+packaging==26.3
+pexpect==4.9.0
+pillow==12.3.0
+ptyprocess==0.7.0

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@
 
 [tox]
 minversion = 1.8
-envlist = py35,pep8
 skip_missing_interpreters = True
 
 [testenv]
@@ -13,6 +12,7 @@ skip_missing_interpreters = True
 deps =
 #     pytest
      -r{toxinidir}/requirements.txt
+allowlist_externals = sh
 
 [testenv:pep8]
 changedir = {toxinidir}


### PR DESCRIPTION
Hello, I don't have much experience with contributing to open source projects so my apologies if anything is wrong.

After trying to use ly2video the other day, I learned that it is incompatible with the latest Python versions due to using multiple deprecated libraries. I have replaced these libraries with the currently-in-use versions to support up to the latest Python 3.14. I then ran the test.py script, ran the tox tests, and used ly2video for all regression tests, all successful. I also confirmed it still works on the oldest supported Python version, 3.10.

Sidenote, I needed to add allowlist_externals = sh to tox.ini in order for it to run, since otherwise it complained about needing to add that line.

Thank you.